### PR TITLE
Create simple AI SAAS template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+<!-- location: README.md -->
+<!-- this README explains the structure and purpose of this template. -->
+<!-- it is not a comprehensive user manual. -->
+
+# AI SAAS Starter
+
+This repo provides a minimal template for an AI Software as a Service project. It keeps the stack simple.
+
+## Tech Stack
+
+- **Frontend:** [Next.js](https://nextjs.org/)
+- **Backend:** [FastAPI](https://fastapi.tiangolo.com/)
+- **Database:** [Supabase](https://supabase.com/)
+- **Icons:** [Lucide React](https://lucide.dev/icons)
+
+## Folder Structure
+
+```
+.
+├── backend        # FastAPI application
+│   ├── app.py
+│   └── requirements.txt
+├── frontend       # Next.js application
+│   ├── pages
+│   │   └── index.tsx
+│   ├── package.json
+│   ├── tsconfig.json
+│   ├── next.config.js
+│   └── next-env.d.ts
+└── index.html     # placeholder landing page
+```
+
+## Setup
+
+### Frontend
+
+1. Install Node.js dependencies.
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Copy `.env.local.example` to `.env.local` and set Supabase keys.
+3. Run the development server.
+   ```bash
+   npm run dev
+   ```
+
+### Backend
+
+1. Install Python packages.
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   ```
+2. Start the API server.
+   ```bash
+   uvicorn app:app --reload
+   ```
+
+Both servers run independently. The frontend communicates with Supabase directly.
+
+## Notes
+
+- The code is intentionally lightweight to serve as a foundation.
+- Adjust authentication, hosting and CI/CD to your needs.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,20 @@
+# backend/app.py
+# this file defines a minimal FastAPI server for the SAAS template.
+# it is not intended for heavy production usage.
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class Message(BaseModel):
+    text: str
+
+@app.get("/hello")
+async def read_root():
+    return {"message": "Hello from FastAPI"}
+
+@app.post("/echo")
+async def echo_message(msg: Message):
+    # simply return the incoming message
+    return {"echo": msg.text}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+# backend/requirements.txt
+# lists python packages needed for the API.
+# it is not a lock file.
+
+fastapi==0.111.0
+uvicorn==0.30.1
+pydantic==2.7.1

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,6 @@
+# location: frontend/.env.local.example
+# example environment variables for Supabase.
+# do not commit sensitive keys here.
+
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_KEY=public-anon-key

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// location: frontend/next-env.d.ts
+// this file ensures TypeScript type support for Next.js.
+// it is not meant for business logic.
+
+// NOTE: This file should not contain actual code.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,13 @@
+/**
+ * location: frontend/next.config.js
+ * this file configures Next.js to use experimental app directory.
+ * it does NOT include advanced custom configuration.
+ */
+
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "//": "location: frontend/package.json",
+  "//2": "defines frontend dependencies for the template.",
+  "//3": "does not hold runtime logic.",
+  "name": "ai-saas-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "lucide-react": "^0.322.0",
+    "@supabase/supabase-js": "^2.39.5"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,34 @@
+// frontend/pages/index.tsx
+// this page renders the main landing page of the SAAS template.
+// it is not a complex dashboard or production ready code.
+
+import { useEffect, useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
+import { Activity } from 'lucide-react';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY || '';
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export default function HomePage() {
+  const [message, setMessage] = useState('');
+
+  // fetch a welcome message from Supabase on load
+  useEffect(() => {
+    async function loadMessage() {
+      const { data } = await supabase.from('messages').select('text').limit(1).single();
+      setMessage(data?.text || 'Hello World');
+    }
+
+    loadMessage();
+  }, []);
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>
+        <Activity style={{ verticalAlign: 'middle' }} /> AI SAAS Template
+      </h1>
+      <p>{message}</p>
+    </main>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "//": "location: frontend/tsconfig.json",
+  "//2": "typescript configuration for Next.js.",
+  "//3": "not used for runtime code.",
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/index.html
+++ b/index.html
@@ -1,3 +1,6 @@
+<!-- index.html -->
+<!-- simple placeholder landing page. -->
+<!-- not part of the Next.js app. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- set up minimal Next.js frontend with Supabase
- add FastAPI backend
- provide environment example and README
- keep simple landing page

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844ec6e298483338b95ad724929fae3