### PR TITLE
Add OpenAI agents

### DIFF
--- a/agents/ChatAgent.jsx
+++ b/agents/ChatAgent.jsx
@@ -1,0 +1,24 @@
+// agents/ChatAgent.jsx
+// Purpose: Defines the ChatAgent for general conversation using the OpenAI Agents SDK.
+// Only the basic agent configuration and a Lucide icon component are included.
+
+import React from "react";
+import OpenAI from "openai";
+import { Agent } from "openai/agents";
+import { MessageCircle } from "lucide-react";
+
+// OpenAI client with API key from environment.
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Generic chat agent.
+export const chatAgent = new Agent({
+  client: openai,
+  instructions: "You provide friendly and concise responses to user questions.",
+  model: "gpt-4-turbo",
+  tools: [],
+});
+
+// Icon component for the chat agent.
+export function ChatAgentIcon() {
+  return <MessageCircle />;
+}

--- a/agents/DataAgent.jsx
+++ b/agents/DataAgent.jsx
@@ -1,0 +1,24 @@
+// agents/DataAgent.jsx
+// Purpose: Defines the DataAgent using the OpenAI Agents SDK with a Lucide React icon.
+// It provides data analysis assistance only; it does not include a full interface.
+
+import React from "react";
+import OpenAI from "openai";
+import { Agent } from "openai/agents";
+import { BarChart2 } from "lucide-react";
+
+// OpenAI client configured with API key from environment.
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Configure the data-focused agent.
+export const dataAgent = new Agent({
+  client: openai,
+  instructions: "You assist with simple data analysis tasks and explanations.",
+  model: "gpt-4-turbo",
+  tools: [],
+});
+
+// Icon component representing the agent.
+export function DataAgentIcon() {
+  return <BarChart2 />;
+}

--- a/agents/ResearchAgent.jsx
+++ b/agents/ResearchAgent.jsx
@@ -1,0 +1,24 @@
+// agents/ResearchAgent.jsx
+// Purpose: Defines the ResearchAgent with the OpenAI Agents SDK. Includes a React icon using Lucide.
+// This file does not implement a full UI. It only configures the agent and exports an icon.
+
+import React from "react";
+import OpenAI from "openai";
+import { Agent } from "openai/agents";
+import { Search } from "lucide-react";
+
+// Create OpenAI client. The API key must be provided through env variables.
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Configure an agent specialized in answering research questions.
+export const researchAgent = new Agent({
+  client: openai,
+  instructions: "You help users gather information and summarize findings.",
+  model: "gpt-4-turbo",
+  tools: [],
+});
+
+// Minimal icon component for the agent.
+export function ResearchAgentIcon() {
+  return <Search />;
+}

--- a/agents/TravelAgent.jsx
+++ b/agents/TravelAgent.jsx
@@ -1,0 +1,24 @@
+// agents/TravelAgent.jsx
+// Purpose: Defines the TravelAgent with the OpenAI Agents SDK and a Lucide icon.
+// This code only sets up the agent and an icon component; no full UI is provided.
+
+import React from "react";
+import OpenAI from "openai";
+import { Agent } from "openai/agents";
+import { Plane } from "lucide-react";
+
+// OpenAI client using API key from environment.
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Agent specialized in travel recommendations.
+export const travelAgent = new Agent({
+  client: openai,
+  instructions: "You plan trips and give concise travel advice.",
+  model: "gpt-4-turbo",
+  tools: [],
+});
+
+// Icon component for the travel agent.
+export function TravelAgentIcon() {
+  return <Plane />;
+}


### PR DESCRIPTION
## Summary
- create a new `agents` folder
- implement four example agents with the OpenAI Agents SDK
- expose a small React icon component for each agent using Lucide icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844ecb6c37883339543c01549fac7b9